### PR TITLE
Oceanwater 455 mitigate shadow acne

### DIFF
--- a/models/atacama_y1a/materials/scripts/ow_terrain.frag
+++ b/models/atacama_y1a/materials/scripts/ow_terrain.frag
@@ -185,7 +185,8 @@ void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNorm
 
   // shadows
   // Compute shadow lookup bias using formula from http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-16-shadow-mapping/
-  // Have not found a way to this by calling glPolygonOffset from Gazebo/Ogre.
+  // Should be able to bake this bias into the shadow map using constant_bias
+  // and slope_scale_bias in IRGShadowParametersPlugins, but it doesn't work.
   float cosTheta = clamp(dot(wsNormal, wsDirToSun), 0.0, 1.0);
   float slopeScaleBias = clamp(0.000001 * tan(acos(cosTheta)), 0.0, 0.000005);
   float shadow = calcPSSMDepthShadow(shadowMap0, shadowMap1, shadowMap2,


### PR DESCRIPTION
The problem appeared as shadow acne, but the solution was quite different. We were seeing some broken terrain self-shadowing where it should not have appeared in the first place. This is because the normalmap for the terrain did not properly describe the normals in the DEM. The normals were not steep enough. Old vs new:
![old](https://user-images.githubusercontent.com/30808090/99014050-bd3f3600-2506-11eb-9d97-4d724a84afcf.png)
![new](https://user-images.githubusercontent.com/30808090/99014052-be706300-2506-11eb-8b1a-c6ae52970d09.png)

There is still some shadow acne, but I have mitigated it as best I can for now in the shader. There should be a way to bias the shadow map during its rendering to accomplish the same effect that I achieved with the shader, but it isn't working. It may be an Ogre bug. I updated a comment in the shader to reflect that.