### PR TITLE
Use exposure 0.05 and energy_conversion 0.005.

### DIFF
--- a/worlds/atacama_y1a.world
+++ b/worlds/atacama_y1a.world
@@ -49,9 +49,9 @@
           </geometry>
           <plugin name="CameraSim" filename="libIRGCameraSimVisualPlugin.so" >
             <topic_uid>gui</topic_uid>
-            <exposure>0.02</exposure>
+            <exposure>0.05</exposure>
             <gamma>1.0</gamma>
-            <energy_conversion>0.01625</energy_conversion>
+            <energy_conversion>0.005</energy_conversion>
             <read_noise>0.0</read_noise>
             <shot_noise>0.0</shot_noise>
           </plugin>

--- a/worlds/terminator.world
+++ b/worlds/terminator.world
@@ -49,9 +49,9 @@
           </geometry>
           <plugin name="CameraSim" filename="libIRGCameraSimVisualPlugin.so" >
             <topic_uid>gui</topic_uid>
-            <exposure>0.02</exposure>
+            <exposure>0.05</exposure>
             <gamma>1.0</gamma>
-            <energy_conversion>0.01625</energy_conversion>
+            <energy_conversion>0.005</energy_conversion>
             <read_noise>0.0</read_noise>
             <shot_noise>0.0</shot_noise>
           </plugin>

--- a/worlds/terminator_workspace.world
+++ b/worlds/terminator_workspace.world
@@ -50,9 +50,9 @@
           </geometry>
           <plugin name="CameraSim" filename="libIRGCameraSimVisualPlugin.so" >
             <topic_uid>gui</topic_uid>
-            <exposure>0.02</exposure>
+            <exposure>0.05</exposure>
             <gamma>1.0</gamma>
-            <energy_conversion>0.01625</energy_conversion>
+            <energy_conversion>0.005</energy_conversion>
             <read_noise>0.0</read_noise>
             <shot_noise>0.0</shot_noise>
           </plugin>

--- a/worlds/test_dem.world
+++ b/worlds/test_dem.world
@@ -50,9 +50,9 @@
           </geometry>
           <plugin name="CameraSim" filename="libIRGCameraSimVisualPlugin.so" >
             <topic_uid>gui</topic_uid>
-            <exposure>0.02</exposure>
+            <exposure>0.05</exposure>
             <gamma>1.0</gamma>
-            <energy_conversion>0.01625</energy_conversion>
+            <energy_conversion>0.005</energy_conversion>
             <read_noise>0.0</read_noise>
             <shot_noise>0.0</shot_noise>
           </plugin>


### PR DESCRIPTION
I updated IRGCameraSim plugin params based on refined camera estimates documented in the "energy_conversion parameter" section of this page: https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/Visuals