### PR TITLE
OCEANWATER-836: Replace $(find ow_lander)/materials/textures with relative path to the image file

### DIFF
--- a/models/atacama_y1a/model.sdf
+++ b/models/atacama_y1a/model.sdf
@@ -43,7 +43,7 @@
             <uri>model://atacama_y1a/materials/scripts</uri>
             <uri>model://atacama_y1a/materials/textures</uri>
             <uri>model://terminator/materials/textures</uri>
-            <uri>$(find ow_lander)/materials/textures</uri>
+            <uri>file://../../ow_simulator/ow_lander/materials/textures/lander_light_beam.png</uri>
             <name>ow/terrain</name>
           </script>
         </material>

--- a/models/terminator/model.sdf
+++ b/models/terminator/model.sdf
@@ -40,7 +40,7 @@
           <script>
             <uri>model://terminator/materials/scripts</uri>
             <uri>model://terminator/materials/textures</uri>
-            <uri>$(find ow_lander)/materials/textures</uri>
+            <uri>file://../../ow_simulator/ow_lander/materials/textures/lander_light_beam.png</uri>
             <name>ow/terrain</name>
           </script>
         </material>

--- a/models/terminator_workspace/model.sdf
+++ b/models/terminator_workspace/model.sdf
@@ -41,7 +41,7 @@
             <uri>model://terminator_workspace/materials/scripts</uri>
             <uri>model://terminator_workspace/materials/textures</uri>
             <uri>model://terminator/materials/textures</uri>
-            <uri>$(find ow_lander)/materials/textures</uri>
+            <uri>file://../../ow_simulator/ow_lander/materials/textures/lander_light_beam.png</uri>
             <name>ow/terrain</name>
           </script>
         </material>

--- a/models/test_dem/model.sdf
+++ b/models/test_dem/model.sdf
@@ -42,7 +42,7 @@
             <uri>model://test_dem/materials/scripts</uri>
             <uri>model://test_dem/materials/textures</uri>
             <uri>model://terminator/materials/textures</uri>
-            <uri>$(find ow_lander)/materials/textures</uri>
+            <uri>file://../../ow_simulator/ow_lander/materials/textures/lander_light_beam.png</uri>
             <name>ow/terrain</name>
           </script>
         </material>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [ N/A ] |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-836 / Resolve URI doesn't exist[$(find ow_lander)/materials/textures]](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-836) |
| Github :octocat:  | N/A |


## Summary of Changes
* Replaced the unrecognized syntax `$(find ow_lander)/materials/textures` found within some of our SDF files with the relative path to the image `lander_light_beam.png`

## Test
### Before applying the fix
* Before checking out this branch, launch the simulation using any of the 4 supplied launch files. For example:
```bash
roslaunch ow atacama_y1a.launch
```
* Once the simulation fully loads verify that gazebo instance is emitting these two messages in the terminal:
```bash
[Wrn] [SystemPaths.cc:459] File or path does not exist [""] [$(find ow_lander)/materials/textures]
[Err] [RenderEngine.cc:480] URI doesn't exist[$(find ow_lander)/materials/textures]
```
### After applying the fix
* Checkout this branch and re-run the simulation again.
* Verify that the previous warning and error messages are gone
* Also verify that the lander spot lights are rendered correctly on the terrain as expected