### PR TITLE
Oceanwater 858 improved regolith removal

### DIFF
--- a/models/atacama_y1a/model.sdf
+++ b/models/atacama_y1a/model.sdf
@@ -60,6 +60,12 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
+      <sensor name="contact_sensor" type="contact">
+        <contact>
+          <collision>collision</collision>
+        </contact>
+        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+      </sensor>
     </link>
   </model>
 </sdf>

--- a/models/atacama_y1a/model.sdf
+++ b/models/atacama_y1a/model.sdf
@@ -60,11 +60,14 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
-      <sensor name="contact_sensor" type="contact">
+      <sensor name="contact_sensor_terrain" type="contact">
         <contact>
           <collision>collision</collision>
         </contact>
-        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+        <plugin name="contact_sensor_terrain_plugin"
+                filename="libContactSensorPlugin.so">
+          <topic>/ow_regolith/contacts/terrain</topic>
+        </plugin>
       </sensor>
     </link>
   </model>

--- a/models/atacama_y1a/model.sdf
+++ b/models/atacama_y1a/model.sdf
@@ -67,6 +67,7 @@
         <plugin name="contact_sensor_terrain_plugin"
                 filename="libContactSensorPlugin.so">
           <topic>/ow_regolith/contacts/terrain</topic>
+          <report_only>regolith_\d*.*</report_only>
         </plugin>
       </sensor>
     </link>

--- a/models/terminator/model.sdf
+++ b/models/terminator/model.sdf
@@ -56,6 +56,12 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
+      <sensor name="contact_sensor" type="contact">
+        <contact>
+          <collision>collision</collision>
+        </contact>
+        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+      </sensor>
     </link>
   </model>
 </sdf>

--- a/models/terminator/model.sdf
+++ b/models/terminator/model.sdf
@@ -63,6 +63,7 @@
         <plugin name="contact_sensor_terrain_plugin"
                 filename="libContactSensorPlugin.so">
           <topic>/ow_regolith/contacts/terrain</topic>
+          <report_only>regolith_\d*.*</report_only>
         </plugin>
       </sensor>
     </link>

--- a/models/terminator/model.sdf
+++ b/models/terminator/model.sdf
@@ -56,11 +56,14 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
-      <sensor name="contact_sensor" type="contact">
+      <sensor name="contact_sensor_terrain" type="contact">
         <contact>
           <collision>collision</collision>
         </contact>
-        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+        <plugin name="contact_sensor_terrain_plugin"
+                filename="libContactSensorPlugin.so">
+          <topic>/ow_regolith/contacts/terrain</topic>
+        </plugin>
       </sensor>
     </link>
   </model>

--- a/models/terminator_workspace/model.sdf
+++ b/models/terminator_workspace/model.sdf
@@ -58,6 +58,12 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
+      <sensor name="contact_sensor" type="contact">
+        <contact>
+          <collision>collision</collision>
+        </contact>
+        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+      </sensor>
     </link>
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so" />
   </model>

--- a/models/terminator_workspace/model.sdf
+++ b/models/terminator_workspace/model.sdf
@@ -58,11 +58,14 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
-      <sensor name="contact_sensor" type="contact">
+      <sensor name="contact_sensor_terrain" type="contact">
         <contact>
           <collision>collision</collision>
         </contact>
-        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+        <plugin name="contact_sensor_terrain_plugin"
+                filename="libContactSensorPlugin.so">
+          <topic>/ow_regolith/contacts/terrain</topic>
+        </plugin>
       </sensor>
     </link>
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so" />

--- a/models/terminator_workspace/model.sdf
+++ b/models/terminator_workspace/model.sdf
@@ -65,6 +65,7 @@
         <plugin name="contact_sensor_terrain_plugin"
                 filename="libContactSensorPlugin.so">
           <topic>/ow_regolith/contacts/terrain</topic>
+          <report_only>regolith_\d*.*</report_only>
         </plugin>
       </sensor>
     </link>

--- a/models/test_dem/model.sdf
+++ b/models/test_dem/model.sdf
@@ -59,11 +59,14 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
-      <sensor name="contact_sensor" type="contact">
+      <sensor name="contact_sensor_terrain" type="contact">
         <contact>
           <collision>collision</collision>
         </contact>
-        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+        <plugin name="contact_sensor_terrain_plugin"
+                filename="libContactSensorPlugin.so">
+          <topic>/ow_regolith/contacts/terrain</topic>
+        </plugin>
       </sensor>
     </link>
   </model>

--- a/models/test_dem/model.sdf
+++ b/models/test_dem/model.sdf
@@ -66,6 +66,7 @@
         <plugin name="contact_sensor_terrain_plugin"
                 filename="libContactSensorPlugin.so">
           <topic>/ow_regolith/contacts/terrain</topic>
+          <report_only>regolith_\d*.*</report_only>
         </plugin>
       </sensor>
     </link>

--- a/models/test_dem/model.sdf
+++ b/models/test_dem/model.sdf
@@ -59,6 +59,12 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
+      <sensor name="contact_sensor" type="contact">
+        <contact>
+          <collision>collision</collision>
+        </contact>
+        <plugin name='terrain_contact_sensor' filename='libTerrainContactPlugin.so'/>
+      </sensor>
     </link>
   </model>
 </sdf>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-680](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-680) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-858](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-858)|
| Github :octocat:  | # |

## Related PRs
[ow_simulator - PR#234](https://github.com/nasa/ow_simulator/pull/234)

## Summary of Changes
* The **ContactSensorPlugin** sensor plugin has been added to all Europa terrain models, so **reoglith node** can remove models that collide with it.

## Test
@kmdalal please perform the test on all 4 worlds.
@Samahu please perform the test on as many as you'd like, but preferably at least one.

Before performing this test make sure you switch your **ow_simulator** branch to **OCEANWATER-858_improved_regolith_removal**, and run `catkin build`.

For each of the 4 following launch files
 * atacama_y1a.launch
 * europa_terminator.launch
 * europa_terminator_workspace.launch
 * europa_test_dem.launch

Perform the following test:
1. `roslaunch ow LAUNCH_FILE`, where "LAUNCH_FILE" is the world you're currently testing.
2. Spawn regolith above the terrain using `rosservice call /ow_regolith/spawn_regolith '[2.0, 0.0, 1.0]' 'lander::base_link'`
3. Check in gzclient that the particle is spawned, falls to the terrain, and is removed upon collision.