### PR TITLE
Use front-face shadow maps. Tune terrain shaders to use them properly.

### DIFF
--- a/models/atacama_y1a/materials/scripts/ow_terrain.frag
+++ b/models/atacama_y1a/materials/scripts/ow_terrain.frag
@@ -125,11 +125,12 @@ float calcPSSMDepthShadowDebug(
   sampler2DShadow shadowMap0, sampler2DShadow shadowMap1, sampler2DShadow shadowMap2,
   vec4 lsPos0, vec4 lsPos1, vec4 lsPos2,
   float invShadowmapSize0, float invShadowmapSize1, float invShadowmapSize2,
-  vec4 pssmSplitPoints, float camDepth)
+  vec4 pssmSplitPoints, float camDepth, float depthBias)
 {
   float shadow = 1.0;
+  vec4 bias = vec4(0.0, 0.0, depthBias, 0.0);
   // calculate shadow
-  shadow = calcDepthShadow(shadowMap0, lsPos0, invShadowmapSize0);
+  shadow = calcDepthShadow(shadowMap0, lsPos0 + bias, invShadowmapSize0);
   return shadow;
 }
 
@@ -185,15 +186,18 @@ void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNorm
   const float specular_power = 100.0;
 
   // shadows
-  // Compute shadow lookup bias using formula from http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-16-shadow-mapping/
+  // Compute shadow lookup bias using formula from
+  // http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-16-shadow-mapping/
   // Should be able to bake this bias into the shadow map using constant_bias
   // and slope_scale_bias in IRGShadowParametersPlugins, but it doesn't work.
+  float constantBias = vsPos.z * 0.00001 - 0.00002; // Normally a constant, but this works better with PSSM
   float cosTheta = clamp(dot(wsNormal, wsDirToSun), 0.0, 1.0);
-  float slopeScaleBias = clamp(0.000001 * tan(acos(cosTheta)), 0.0, 0.000005);
+  float slopeScaleBias = clamp(0.000004 * tan(acos(cosTheta)), 0.0, 0.001);
+  float bias = constantBias - slopeScaleBias;
   float shadow = calcPSSMDepthShadow(shadowMap0, shadowMap1, shadowMap2,
                                      lsPos[0], lsPos[1], lsPos[2],
                                      inverseShadowmapSize[0], inverseShadowmapSize[1], inverseShadowmapSize[2],
-                                     pssmSplitPoints, -vsPos.z, slopeScaleBias);
+                                     pssmSplitPoints, -vsPos.z, bias);
 
   // Only the highest parts of bumps should be lit when sun is at glancing angles
   // This removes a great deal of impossible light in shaded areas and hides shadow artifacts.

--- a/models/terminator/materials/scripts/ow_terrain.frag
+++ b/models/terminator/materials/scripts/ow_terrain.frag
@@ -100,21 +100,22 @@ float calcPSSMDepthShadow(
   sampler2DShadow shadowMap0, sampler2DShadow shadowMap1, sampler2DShadow shadowMap2,
   vec4 lsPos0, vec4 lsPos1, vec4 lsPos2,
   float invShadowmapSize0, float invShadowmapSize1, float invShadowmapSize2,
-  vec4 pssmSplitPoints, float camDepth)
+  vec4 pssmSplitPoints, float camDepth, float depthBias)
 {
   float shadow = 1.0;
+  vec4 bias = vec4(0.0, 0.0, depthBias, 0.0);
   // calculate shadow
   if (camDepth <= pssmSplitPoints.x)
   {
-    shadow = calcDepthShadow(shadowMap0, lsPos0, invShadowmapSize0);
+    shadow = calcDepthShadow(shadowMap0, lsPos0 + bias, invShadowmapSize0);
   }
   else if (camDepth <= pssmSplitPoints.y)
   {
-    shadow = calcDepthShadow(shadowMap1, lsPos1, invShadowmapSize1);
+    shadow = calcDepthShadow(shadowMap1, lsPos1 + bias, invShadowmapSize1);
   }
   else if (camDepth <= pssmSplitPoints.z)
   {
-    shadow = calcDepthShadow(shadowMap2, lsPos2, invShadowmapSize2);
+    shadow = calcDepthShadow(shadowMap2, lsPos2 + bias, invShadowmapSize2);
   }
   return shadow;
 }
@@ -123,11 +124,12 @@ float calcPSSMDepthShadowDebug(
   sampler2DShadow shadowMap0, sampler2DShadow shadowMap1, sampler2DShadow shadowMap2,
   vec4 lsPos0, vec4 lsPos1, vec4 lsPos2,
   float invShadowmapSize0, float invShadowmapSize1, float invShadowmapSize2,
-  vec4 pssmSplitPoints, float camDepth)
+  vec4 pssmSplitPoints, float camDepth, float depthBias)
 {
   float shadow = 1.0;
+  vec4 bias = vec4(0.0, 0.0, depthBias, 0.0);
   // calculate shadow
-  shadow = calcDepthShadow(shadowMap0, lsPos0, invShadowmapSize0);
+  shadow = calcDepthShadow(shadowMap0, lsPos0 + bias, invShadowmapSize0);
   return shadow;
 }
 
@@ -183,10 +185,18 @@ void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNorm
   const float specular_power = 100.0;
 
   // shadows
+  // Compute shadow lookup bias using formula from
+  // http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-16-shadow-mapping/
+  // Should be able to bake this bias into the shadow map using constant_bias
+  // and slope_scale_bias in IRGShadowParametersPlugins, but it doesn't work.
+  float constantBias = vsPos.z * 0.00001 - 0.00002; // Normally a constant, but this works better with PSSM
+  float cosTheta = clamp(dot(wsNormal, wsDirToSun), 0.0, 1.0);
+  float slopeScaleBias = clamp(0.000004 * tan(acos(cosTheta)), 0.0, 0.001);
+  float bias = constantBias - slopeScaleBias;
   float shadow = calcPSSMDepthShadow(shadowMap0, shadowMap1, shadowMap2,
                                      lsPos[0], lsPos[1], lsPos[2],
                                      inverseShadowmapSize[0], inverseShadowmapSize[1], inverseShadowmapSize[2],
-                                     pssmSplitPoints, -vsPos.z);
+                                     pssmSplitPoints, -vsPos.z, bias);
 
   // Only the highest parts of bumps should be lit when sun is at glancing angles
   // This removes a great deal of impossible light in shaded areas and hides shadow artifacts.

--- a/models/terminator/model.sdf
+++ b/models/terminator/model.sdf
@@ -45,8 +45,8 @@
           </script>
         </material>
         <plugin name="lod" filename="libHeightmapLODPlugin.so">
-          <lod>3</lod>
-          <skirt_length>0.1</skirt_length>
+          <lod>0</lod>
+          <skirt_length>0.0</skirt_length>
         </plugin>
         <plugin name="shadow_params" filename="libIRGShadowParametersVisualPlugin.so">
           <shadow_texture_size>4096</shadow_texture_size>

--- a/worlds/atacama_y1a.world
+++ b/worlds/atacama_y1a.world
@@ -12,6 +12,8 @@
       <shadows>1</shadows>
       <grid>false</grid>
       <origin_visual>false</origin_visual>
+      <!-- Render shadows using front faces instead of back faces -->
+      <ignition:shadow_caster_render_back_faces>0</ignition:shadow_caster_render_back_faces>
     </scene>
 
     <physics type='ode'>

--- a/worlds/terminator.world
+++ b/worlds/terminator.world
@@ -12,6 +12,8 @@
       <shadows>1</shadows>
       <grid>false</grid>
       <origin_visual>false</origin_visual>
+      <!-- Render shadows using front faces instead of back faces -->
+      <ignition:shadow_caster_render_back_faces>0</ignition:shadow_caster_render_back_faces>
     </scene>
 
     <physics type='ode'>

--- a/worlds/terminator_workspace.world
+++ b/worlds/terminator_workspace.world
@@ -13,6 +13,8 @@
       <shadows>1</shadows>
       <grid>false</grid>
       <origin_visual>false</origin_visual>
+      <!-- Render shadows using front faces instead of back faces -->
+      <ignition:shadow_caster_render_back_faces>0</ignition:shadow_caster_render_back_faces>
     </scene>
 
     <physics type='ode'>

--- a/worlds/test_dem.world
+++ b/worlds/test_dem.world
@@ -13,6 +13,8 @@
       <shadows>1</shadows>
       <grid>false</grid>
       <origin_visual>false</origin_visual>
+      <!-- Render shadows using front faces instead of back faces -->
+      <ignition:shadow_caster_render_back_faces>0</ignition:shadow_caster_render_back_faces>
     </scene>
 
     <physics type='ode'>


### PR DESCRIPTION
Still not perfect, but better than before. Note the lit speckles in the interior of large shadows have been removed. That was my main gripe with the shadows we had. Tuning shadows for all cases is probably impossible. For example, the thin walls of our scoop require a very high-res shadow map, but that takes resolution away from the other maps. It would probably help a lot if Ogre's implementation of PSSM used 4 shadow maps instead of 3.

Before:
![original](https://user-images.githubusercontent.com/30808090/165382979-7965c702-d6d0-4820-ae47-328dbaee6503.jpg)
After:
![fixed](https://user-images.githubusercontent.com/30808090/165383049-14d883a4-7d16-4bbe-9614-3f8451d4790d.jpg)

