### PR TITLE
changed report_only value

### DIFF
--- a/models/atacama_y1a/model.sdf
+++ b/models/atacama_y1a/model.sdf
@@ -65,7 +65,7 @@
         <plugin name="contact_sensor_terrain_plugin"
                 filename="libContactSensorPlugin.so">
           <topic>/ow_regolith/contacts/terrain</topic>
-          <report_only>regolith_\d*.*</report_only>
+          <report_only>regolith_\d*</report_only>
         </plugin>
       </sensor>
     </link>

--- a/models/terminator/model.sdf
+++ b/models/terminator/model.sdf
@@ -56,16 +56,6 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
-      <sensor name="contact_sensor_terrain" type="contact">
-        <contact>
-          <collision>collision</collision>
-        </contact>
-        <plugin name="contact_sensor_terrain_plugin"
-                filename="libContactSensorPlugin.so">
-          <topic>/ow_regolith/contacts/terrain</topic>
-          <report_only>regolith_\d*.*</report_only>
-        </plugin>
-      </sensor>
     </link>
   </model>
 </sdf>

--- a/models/terminator_workspace/model.sdf
+++ b/models/terminator_workspace/model.sdf
@@ -65,7 +65,7 @@
         <plugin name="contact_sensor_terrain_plugin"
                 filename="libContactSensorPlugin.so">
           <topic>/ow_regolith/contacts/terrain</topic>
-          <report_only>regolith_\d*.*</report_only>
+          <report_only>regolith_\d*</report_only>
         </plugin>
       </sensor>
     </link>

--- a/models/test_dem/model.sdf
+++ b/models/test_dem/model.sdf
@@ -58,16 +58,6 @@
           <shadow_split_padding>2</shadow_split_padding>
         </plugin>
       </visual>
-      <sensor name="contact_sensor_terrain" type="contact">
-        <contact>
-          <collision>collision</collision>
-        </contact>
-        <plugin name="contact_sensor_terrain_plugin"
-                filename="libContactSensorPlugin.so">
-          <topic>/ow_regolith/contacts/terrain</topic>
-          <report_only>regolith_\d*.*</report_only>
-        </plugin>
-      </sensor>
     </link>
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so" />
   </model>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-812](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-812) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1171](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1171) |

## Sibling PRs
[ow_simulator](https://github.com/nasa/ow_simulator/pull/378)

## Summary of Changes
* Removed the ContactSensor plugin from worlds that do not support terrain modification.
* Simplified the **report_only** element of the ContactSensorPlugin in the remaining worlds. 

## Test
Refer to the sibling PR in ow_simulator
