### PR TITLE
Added dynamic terrain model plugin to world to suppress LCP message

### DIFF
--- a/models/terminator/model.sdf
+++ b/models/terminator/model.sdf
@@ -57,5 +57,9 @@
         </plugin>
       </visual>
     </link>
+    <!-- This world does not support dynamic terrain, but including the dynamic
+         terrain model plugin suppresses an frequent ODE message. -->
+    <plugin name="ow_dynamic_terrain_model"
+            filename="libow_dynamic_terrain_model.so" />
   </model>
 </sdf>

--- a/models/test_dem/model.sdf
+++ b/models/test_dem/model.sdf
@@ -59,6 +59,9 @@
         </plugin>
       </visual>
     </link>
-    <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so" />
+    <!-- This world does not support dynamic terrain, but including the dynamic
+         terrain model plugin suppresses an frequent ODE message. -->
+    <plugin name="ow_dynamic_terrain_model"
+            filename="libow_dynamic_terrain_model.so" />
   </model>
 </sdf>


### PR DESCRIPTION
[OW-1258](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1258)

## Summary of Changes
Added dynamic terrain model plugin to world to suppress LCP message

## Test
1. Start sim in europa_terminator 
2. Command an arm movement that collides with the terrain `rosrun ow_lander arm_move_cartesian.py -x 1.8 -e 1.5 0 0`

When the arm collides there should be no message of the form 
```
ODE Message 3: LCP internal error, s <= 0 (s=-2.0200e+02)
```
In noetic-devel this message would print. 
