### PR TITLE
MaterialDistributionPlugin added to terminator workspace

### DIFF
--- a/models/terminator_workspace/model.sdf
+++ b/models/terminator_workspace/model.sdf
@@ -70,5 +70,6 @@
       </sensor>
     </link>
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so" />
+    <plugin name="materials_distribution_plugin" filename="libMaterialDistributionPlugin.so" />
   </model>
 </sdf>


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1250](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1250)
Jira Ticket 🎟️ | [OCEANWATER-1235](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1235)

## Sibling PR
https://github.com/nasa/ow_simulator/pull/400

## Summary of Changes
* Regolith can now again be simulated in europa_terminator_workspace 

## Test
See sibling PR