### PR TITLE
updated MaterialDistributionPlugin parameters

### DIFF
--- a/models/atacama_y1a/model.sdf
+++ b/models/atacama_y1a/model.sdf
@@ -85,8 +85,9 @@
     </link>
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so" />
     <plugin name="materials_distribution_plugin" filename="libMaterialDistributionPlugin.so">
-      <corner_a>0  -1   0.3</corner_a>
-      <corner_b>1.3 1   0.0</corner_b>
+      <relative_to>base_link</relative_to>
+      <corner_a>1  -1   0.1</corner_a>
+      <corner_b>2.3 1   -0.37</corner_b>
       <cell_side_length>0.0075</cell_side_length>
       <materials>
         <reference_color material="ICE">         255 255 255  </reference_color>

--- a/models/atacama_y1a/model.sdf
+++ b/models/atacama_y1a/model.sdf
@@ -84,7 +84,12 @@
       </sensor>
     </link>
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so" />
-    <plugin name="materials_distribution_plugin" filename="libMaterialDistributionPlugin.so">
+    <plugin name="materials_distribution_plugin"
+            filename="libMaterialDistributionPlugin.so">
+      <!-- NOTE: The grid requires a surface level to the XY plane, so that it
+           can align with operations happening to the terrain heightmap;
+           therefore, only models level to the XY plane should be used as
+           in the relative_to parameter. -->
       <relative_to>base_link</relative_to>
       <corner_a>1  -1   0.1</corner_a>
       <corner_b>2.3 1   -0.37</corner_b>


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1164](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1164)

## Sibling PR
https://github.com/nasa/ow_simulator/pull/401

## Summary of Changes
New relative_to argument added to MaterialDistributionPlugin's implementation in atacama_y1a's model.sdf. Domain corners adjusted to be relative to the base_link. 

## Test
See instructions in sibling PR.